### PR TITLE
Replace String with CommonMark types for Documentation parameters

### DIFF
--- a/Sources/SwiftMarkup/DiscussionPart.swift
+++ b/Sources/SwiftMarkup/DiscussionPart.swift
@@ -1,4 +1,4 @@
-import CommonMark
+@_exported import CommonMark
 
 /// A part of the discussion.
 public enum DiscussionPart {

--- a/Sources/SwiftMarkup/Documentation.swift
+++ b/Sources/SwiftMarkup/Documentation.swift
@@ -1,12 +1,10 @@
+@_exported import CommonMark
 import Foundation
-import CommonMark
-
-// MARK: -
 
 /// Documentation for a Swift declaration.
 public struct Documentation: Hashable, Codable {
     /// The summary.
-    public var summary: String?
+    public var summary: Paragraph?
 
     /// The text segments and callouts that comprise the discussion, if any.
     public var discussionParts: [DiscussionPart] = []
@@ -15,10 +13,10 @@ public struct Documentation: Hashable, Codable {
     public var parameters: [Parameter] = []
 
     /// The documented return value.
-    public var returns: String?
+    public var returns: Document?
 
     /// The documented error throwing behavior.
-    public var `throws`: String?
+    public var `throws`: Document?
 
     /// Whether the documentation has any content.
     public var isEmpty: Bool {
@@ -43,7 +41,7 @@ public struct Documentation: Hashable, Codable {
         guard let text = text else { return .init() }
         let document = try Document(text)
         let parser = Parser()
-        parser.visitDocument(document)
+        try parser.visitDocument(document)
         return parser.documentation
     }
 }
@@ -53,36 +51,28 @@ public struct Documentation: Hashable, Codable {
 extension Documentation {
     private final class Parser {
         private enum State {
-            case initial
             case summary
             case discussion
             case parameters
         }
 
-        private var state: State = .initial
+        private var state: State = .summary
 
         var documentation: Documentation = Documentation()
 
-        func visitDocument(_ node: Document) {
-            assert(state == .initial)
-            guard let firstChild = node.children.first else {
-                return
-            }
-
-            state = firstChild is Paragraph ? .summary : .discussion
-
+        func visitDocument(_ node: Document) throws {
             for case let child in node.removeChildren() {
-                visitBlock(child)
+                try visitBlock(child)
             }
         }
 
-        private func visitBlock(_ node: Node & Block) {
+        private func visitBlock(_ node: Node & Block) throws {
             switch (state, node) {
-            case (.summary, _):
-                documentation.summary = node.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            case (.summary, let node as Paragraph):
+                documentation.summary = node
                 state = .discussion
             case (.discussion, let list as List) where list.kind == .bullet:
-                visitBulletList(list)
+                try visitBulletList(list)
             default:
                 if let part = DiscussionPart(node) {
                     documentation.discussionParts += [part]
@@ -90,15 +80,15 @@ extension Documentation {
             }
         }
 
-        private func visitBulletList(_ node: List) {
+        private func visitBulletList(_ node: List) throws {
             for item in node.children {
-                visitBulletListItem(item)
+                try visitBulletListItem(item)
             }
 
             state = .discussion
         }
 
-        private func visitBulletListItem(_ node: List.Item) {
+        private func visitBulletListItem(_ node: List.Item) throws {
             func appendListItemToDiscussion(_ item: List.Item) {
                 var list: List
                 if case let .list(lastPart) = documentation.discussionParts.last {
@@ -120,7 +110,7 @@ extension Documentation {
 
             let string = node.description
             let pattern = #"\s*[\-\+\*]\s*(?<parameter>(?:Parameter\s+)?)(?<name>[\w\h]+):(\s*(?<description>.+))?"#
-            let regularExpression = try! NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators, .caseInsensitive])
+            let regularExpression = try NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators, .caseInsensitive])
 
             guard let match = regularExpression.firstMatch(in: string, options: [], range: NSRange(string.startIndex ..< string.endIndex, in: string)),
                 let parameterRange = Range(match.range(at: 1), in: string),
@@ -148,15 +138,15 @@ extension Documentation {
                 if name.caseInsensitiveCompare("parameters") == .orderedSame {
                     state = .parameters
                     for case let nestedBulletList as List in node.children where nestedBulletList.kind == .bullet {
-                        visitBulletList(nestedBulletList)
+                        try visitBulletList(nestedBulletList)
                     }
                 } else if name.caseInsensitiveCompare("parameter") == .orderedSame {
                     let parameter = Parameter(name: name, description: description)
                     documentation.parameters += [parameter]
                 } else if name.caseInsensitiveCompare("returns") == .orderedSame {
-                    documentation.returns = description
+                    documentation.returns = try Document(description)
                 } else if name.caseInsensitiveCompare("throws") == .orderedSame {
-                    documentation.throws = description
+                    documentation.throws = try Document(description)
                 } else if let delimiter = Callout.Delimiter(rawValue: name.lowercased()) {
                     let callout = Callout(delimiter: delimiter, content: description)
                     documentation.discussionParts += [.callout(callout)]

--- a/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
+++ b/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
@@ -44,7 +44,7 @@ final class SwiftMarkupTests: XCTestCase {
 
         XCTAssertEqual(documentation.isEmpty, false)
 
-        XCTAssertEqual(documentation.summary, "Creates a new bicycle with the provided parts and specifications.")
+        XCTAssertEqual(documentation.summary?.description, "Creates a new bicycle with the provided parts and specifications.\n")
         XCTAssertEqual(documentation.discussionParts.count, 7)
 
         guard case .callout(let remark) = documentation.discussionParts[0] else { fatalError() }
@@ -80,9 +80,9 @@ final class SwiftMarkupTests: XCTestCase {
         XCTAssertEqual(documentation.parameters[3].name, "frameSize")
         XCTAssertEqual(documentation.parameters[3].content,"The frame size of the bicycle, in centimeters")
 
-        XCTAssertEqual(documentation.returns, "A beautiful, brand-new bicycle, custom-built just for you.")
+        XCTAssertEqual(documentation.returns?.description, "A beautiful, brand-new bicycle, custom-built just for you.\n")
 
-        XCTAssertEqual(documentation.throws,
+        XCTAssertEqual(documentation.throws?.description,
         #"""
           - `Error.invalidSpecification` if something's wrong with the design
           - `Error.partOutOfStock` if a part needs to be ordered
@@ -99,12 +99,12 @@ final class SwiftMarkupTests: XCTestCase {
         let decoder = JSONDecoder()
         let decoded = try decoder.decode(Documentation.self, from: data)
 
-        XCTAssertEqual(original.summary, decoded.summary)
+        XCTAssertEqual(original.summary?.description, decoded.summary?.description)
         for (expected, actual) in zip(original.discussionParts, decoded.discussionParts) {
             XCTAssertEqual(actual, expected)
         }
         XCTAssertEqual(original.parameters, decoded.parameters)
-        XCTAssertEqual(original.throws, decoded.throws)
-        XCTAssertEqual(original.returns, decoded.returns)
+        XCTAssertEqual(original.throws?.description, decoded.throws?.description)
+        XCTAssertEqual(original.returns?.description, decoded.returns?.description)
     }
 }

--- a/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
+++ b/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
@@ -1,5 +1,4 @@
 @testable import SwiftMarkup
-import CommonMark
 import XCTest
 
 let markdown = #"""


### PR DESCRIPTION
Currently, there's an mismatch in how we treat `Documentation` components. Its `summary`, `returns`, and `throws` are `String`, but its `discussionParts` have associated values that are CommonMark nodes. In practice, this can result in double-parsing (for example, **bold** text in a `summary`, or a list in `throws`).

I believe my original approach was informed by the current limitations in vending types from a dependency. However, we can work around that with an `@_exported import` of CommonMark. I'm pretty sure this is a better approach, but I'd be more confident with a +1 from my @SwiftDocOrg/collaborators.