### PR TITLE
Use exported CommonMark types for Parameter

### DIFF
--- a/Sources/SwiftMarkup/Documentation.swift
+++ b/Sources/SwiftMarkup/Documentation.swift
@@ -132,7 +132,7 @@ extension Documentation {
             switch state {
             case .parameters,
                  _ where !parameterRange.isEmpty:
-                let parameter = Parameter(name: name, description: description)
+                let parameter = try Parameter(name: name, description: description)
                 documentation.parameters += [parameter]
             case .discussion:
                 if name.caseInsensitiveCompare("parameters") == .orderedSame {
@@ -141,7 +141,7 @@ extension Documentation {
                         try visitBulletList(nestedBulletList)
                     }
                 } else if name.caseInsensitiveCompare("parameter") == .orderedSame {
-                    let parameter = Parameter(name: name, description: description)
+                    let parameter = try Parameter(name: name, description: description)
                     documentation.parameters += [parameter]
                 } else if name.caseInsensitiveCompare("returns") == .orderedSame {
                     documentation.returns = try Document(description)

--- a/Sources/SwiftMarkup/Parameter.swift
+++ b/Sources/SwiftMarkup/Parameter.swift
@@ -1,10 +1,12 @@
+@_exported import CommonMark
+
 public struct Parameter: Hashable, Codable {
     public let name: String
-    public let content: String
+    public let content: Document
 
-    init(name: String, description: String) {
+    init(name: String, description: String) throws {
         self.name = name
-        self.content = description
+        self.content = try Document(description)
     }
 }
 

--- a/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
+++ b/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
@@ -71,13 +71,13 @@ final class SwiftMarkupTests: XCTestCase {
 
         XCTAssertEqual(documentation.parameters.count, 4)
         XCTAssertEqual(documentation.parameters[0].name, "style")
-        XCTAssertEqual(documentation.parameters[0].content,"The style of the bicycle")
+        XCTAssertEqual(documentation.parameters[0].content.description, "The style of the bicycle\n")
         XCTAssertEqual(documentation.parameters[1].name, "gearing")
-        XCTAssertEqual(documentation.parameters[1].content,"The gearing of the bicycle")
+        XCTAssertEqual(documentation.parameters[1].content.description, "The gearing of the bicycle\n")
         XCTAssertEqual(documentation.parameters[2].name, "handlebar")
-        XCTAssertEqual(documentation.parameters[2].content,"The handlebar of the bicycle")
+        XCTAssertEqual(documentation.parameters[2].content.description, "The handlebar of the bicycle\n")
         XCTAssertEqual(documentation.parameters[3].name, "frameSize")
-        XCTAssertEqual(documentation.parameters[3].content,"The frame size of the bicycle, in centimeters")
+        XCTAssertEqual(documentation.parameters[3].content.description, "The frame size of the bicycle, in centimeters\n")
 
         XCTAssertEqual(documentation.returns?.description, "A beautiful, brand-new bicycle, custom-built just for you.\n")
 
@@ -102,7 +102,7 @@ final class SwiftMarkupTests: XCTestCase {
         for (expected, actual) in zip(original.discussionParts, decoded.discussionParts) {
             XCTAssertEqual(actual, expected)
         }
-        XCTAssertEqual(original.parameters, decoded.parameters)
+        XCTAssertEqual(original.parameters.description, decoded.parameters.description)
         XCTAssertEqual(original.throws?.description, decoded.throws?.description)
         XCTAssertEqual(original.returns?.description, decoded.returns?.description)
     }


### PR DESCRIPTION
Follow-up to #6 that gives the same treatment to `Parameter`.