### PR TITLE
Add support for custom callouts

### DIFF
--- a/Sources/SwiftMarkup/Callout.swift
+++ b/Sources/SwiftMarkup/Callout.swift
@@ -236,7 +236,10 @@ public struct Callout: Hashable, Codable {
         case custom(String)
     }
 
+    /// The callout delimiter.
     public var delimiter: Delimiter
+
+    /// The content of the callout.
     public var content: String
 }
 

--- a/Sources/SwiftMarkup/Callout.swift
+++ b/Sources/SwiftMarkup/Callout.swift
@@ -1,24 +1,26 @@
+import Foundation
+
 /// A documentation callout, such as a note, remark, or warning.
 public struct Callout: Hashable, Codable {
-    public enum Delimiter: String, Hashable, CaseIterable, Codable {
+    public enum Delimiter: Hashable {
         /**
          Highlighted information for the user of the symbol.
 
          An example of using the `Attention` callout:
 
-           - Attention: What I if told you
+         - Attention: What I if told you
          you read this line wrong?
          */
-        case attention = "Attention"
+        case attention
 
         /**
          The author of the code for a symbol.
 
          An example of using the `Author` callout:
 
-           - Author: William Shakespeare
+         - Author: William Shakespeare
          */
-        case author = "Author"
+        case author
 
         /**
          The authors of the code for a symbol.
@@ -27,75 +29,75 @@ public struct Callout: Hashable, Codable {
 
          An example of using the `Authors` callout:
 
-           - Authors:
-            Plato
+         - Authors:
+         Plato
 
-            Aristotle
+         Aristotle
 
-            Other amazing
-            classical folk
+         Other amazing
+         classical folk
          */
-        case authors = "Authors"
+        case authors
 
         /**
          A bug for a symbol.
 
          An example of using the `Bug` callout:
 
-           - Bug:
-           [*bugExample* contains a memory leak](BugDB://problem/1367823)
+         - Bug:
+         [*bugExample* contains a memory leak](BugDB://problem/1367823)
 
-           - Bug:
-           [Passing a `UIViewController` crashes *bugExample*](BugDB://problem/2274610)
+         - Bug:
+         [Passing a `UIViewController` crashes *bugExample*](BugDB://problem/2274610)
          */
-        case bug = "Bug"
+        case bug
 
         /**
          The algorithmic complexity of a method or function.
 
          An example of using the `Complexity` callout:
 
-           - Complexity:
-           The method demonstrates an inefficient way to sort
-           using an O(N\*N\*N) (order N-cubed) algorithm
+         - Complexity:
+         The method demonstrates an inefficient way to sort
+         using an O(N\*N\*N) (order N-cubed) algorithm
          */
-        case complexity = "Complexity"
+        case complexity
 
         /**
          Copyright information for a symbol.
 
          An example of using the `Copyright` callout:
 
-           - Copyright: Copyright © 1215
-           by The Group of Barrons
+         - Copyright: Copyright © 1215
+         by The Group of Barrons
          */
-        case copyright = "Copyright"
+        case copyright
 
         /**
          A date associated with a symbol.
 
          An example of using the `Date` callout:
 
-           Last date this example was changed
-           - Date: August 19, 2015
+         Last date this example was changed
+         - Date: August 19, 2015
 
-           Days the method produces special results
-           - Date: 12/31
-           - Date: 03/17
+         Days the method produces special results
+         - Date: 12/31
+         - Date: 03/17
          */
-        case date = "Date"
+        case date
 
         /**
          A suggestion to the user for usage of a method or function.
 
          An example of using the `Experiment` callout:
 
-           - Experiment: Pass in a string in the present tense
-           - Experiment: Pass in a string with no vowels
-           - Experiment:
-           Change the third case statement to work only with consonants
+         - Experiment: Pass in a string in the present tense
+         - Experiment: Pass in a string with no vowels
+         - Experiment:
+         Change the third case statement to work only with consonants
          */
-        case experiment = "Experiment"
+        case experiment
 
         /**
          Information that can have adverse effects on the tasks a user is trying to accomplish
@@ -103,65 +105,65 @@ public struct Callout: Hashable, Codable {
          An example of using the `Important` callout:
 
          - Important:
-           "The beginning is the most important part of the work."
-           \
-           –Plato
+         "The beginning is the most important part of the work."
+         \
+         –Plato
          */
-        case important = "Important"
+        case important
 
         /**
          A condition that is guaranteed to be true during the execution of the documented symbol.
 
          An example of using the `Invariant` callout:
 
-           - Invariant:
-           The person reference will not change during the execution of this method
+         - Invariant:
+         The person reference will not change during the execution of this method
          */
-        case invariant = "Invariant"
+        case invariant
 
         /**
          A note to the user of the symbol.
 
          An example of using the `Note` callout:
 
-           - Note:
-           This method returns an estimate.
-           Use `reallyAccurateReading` to get the best results.
+         - Note:
+         This method returns an estimate.
+         Use `reallyAccurateReading` to get the best results.
          */
-        case note = "Note"
+        case note
 
         /**
          A condition that must hold for the symbol to work.
 
          An example of using the `Precondition` callout:
 
-           - Precondition: The `person` property must be non-nil.
-           - Precondition: `updatedAddress` must be a valid address.
+         - Precondition: The `person` property must be non-nil.
+         - Precondition: `updatedAddress` must be a valid address.
          */
-        case precondition = "Precondition"
+        case precondition
 
         /**
          A condition of guaranteed values upon completion of the execution of the symbol.
 
          An example of using the `Postcondition` callout:
 
-           - Postcondition:
-           After completing this method the billing address for
-           the person will be set to `updatedAddress` if it is valid.
-           Otherwise the billing address will not be changed.
+         - Postcondition:
+         After completing this method the billing address for
+         the person will be set to `updatedAddress` if it is valid.
+         Otherwise the billing address will not be changed.
          */
-        case postcondition = "Postcondition"
+        case postcondition
 
         /**
          A remark to the user of the symbol.
 
          An example of using the `Remark` callout:
 
-          - Remark:
-          The performance could be reduced from N-squared to
-          N-log-N by switching patterns.
+         - Remark:
+         The performance could be reduced from N-squared to
+         N-log-N by switching patterns.
          */
-        case remark = "Remark"
+        case remark
 
         /**
          A requirement for the symbol to work.
@@ -170,67 +172,68 @@ public struct Callout: Hashable, Codable {
 
          An example of using the `Requires` callout:
 
-           - Requires: `start <= end`.
-           - Requires: `count > 0`.
+         - Requires: `start <= end`.
+         - Requires: `count > 0`.
          */
-        case requires = "Requires"
+        case requires
 
         /**
          A references to other information.
 
          An example of using the `SeeAlso` callout:
 
-           - SeeAlso:
-           [My Library Reference](https://example.com)
+         - SeeAlso:
+         [My Library Reference](https://example.com)
          */
-        case seealso = "See Also"
+        case seealso
 
         /**
          Information about when the symbol became available, which may include dates, framework versions, and operating system versions.
 
          An example of using the `Since` callout:
 
-           - Since: First available in Mac OS 7
+         - Since: First available in Mac OS 7
          */
-        case since = "Since"
+        case since
 
         /**
          A task required to complete or update the functionality of the symbol.
 
          An example of using the `ToDo` callout:
 
-           - ToDo: Run code coverage and add tests
+         - ToDo: Run code coverage and add tests
          */
-        case todo = "To Do"
+        case todo
 
         /**
          Version information for the symbol.
 
          An example of using the `Version` callout:
 
-           - Version: 0.1 (61A329)
+         - Version: 0.1 (61A329)
          */
-        case version = "Version"
+        case version
 
         /**
          A warning for the user of the symbol.
 
          An example of using the `Warning` callout:
 
-           - Warning:
-           Not all code paths for this method have been tested
+         - Warning:
+         Not all code paths for this method have been tested
          */
-        case warning = "Warning"
+        case warning
 
-        init?(_ description: String) {
-            let description = description.normalized
 
-            if let delimiter = Delimiter.allCases.first(where: { $0.rawValue.normalized == description }) {
-                self = delimiter
-            } else {
-                return nil
-            }
-        }
+        /**
+         A callout with a custom title.
+
+         An example of using a custom callout:
+
+         * Callout(Llama Spotting Tips):
+           Pack warm clothes with your binoculars.
+         */
+        case custom(String)
     }
 
     public var delimiter: Delimiter
@@ -245,8 +248,128 @@ extension Callout: CustomStringConvertible {
     }
 }
 
-fileprivate extension String {
-    var normalized: String {
-        filter { !$0.isWhitespace }.lowercased()
+// MARK: - RawRepresentable
+
+extension Callout.Delimiter: RawRepresentable {
+    public init?(rawValue: String) {
+        switch rawValue.filter({ !$0.isWhitespace }).lowercased() {
+        case "attention":
+            self = .attention
+        case "author":
+            self = .author
+        case "authors":
+            self = .authors
+        case "bug":
+            self = .bug
+        case "complexity":
+            self = .complexity
+        case "copyright":
+            self = .copyright
+        case "date":
+            self = .date
+        case "experiment":
+            self = .experiment
+        case "important":
+            self = .important
+        case "invariant":
+            self = .invariant
+        case "note":
+            self = .note
+        case "precondition":
+            self = .precondition
+        case "postcondition":
+            self = .postcondition
+        case "remark":
+            self = .remark
+        case "requires":
+            self = .requires
+        case "seealso":
+            self = .seealso
+        case "since":
+            self = .since
+        case "todo":
+            self = .todo
+        case "version":
+            self = .version
+        case "warning":
+            self = .warning
+        default:
+            if rawValue.hasSuffix(")"),
+               let openParenthisIndex = rawValue.firstIndex(of: "("),
+               rawValue.prefix(upTo: openParenthisIndex).lowercased() == "custom",
+               let startIndex = rawValue.index(openParenthisIndex, offsetBy: 1, limitedBy: rawValue.endIndex),
+               let endIndex = rawValue.lastIndex(of: ")")
+            {
+                self = .custom(String(rawValue[startIndex..<endIndex]))
+            } else {
+                return nil
+            }
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .attention:
+            return "Attention"
+        case .author:
+            return "Author"
+        case .authors:
+            return "Authors"
+        case .bug:
+            return "Bug"
+        case .complexity:
+            return "Complexity"
+        case .copyright:
+            return "Copyright"
+        case .custom(let callout):
+            return "Custom(\(callout))"
+        case .date:
+            return "Date"
+        case .experiment:
+            return "Experiment"
+        case .important:
+            return "Important"
+        case .invariant:
+            return "Invariant"
+        case .note:
+            return "Note"
+        case .precondition:
+            return "Precondition"
+        case .postcondition:
+            return "Postcondition"
+        case .remark:
+            return "Remark"
+        case .requires:
+            return "Requires"
+        case .seealso:
+            return "See Also"
+        case .since:
+            return "Since"
+        case .todo:
+            return "To Do"
+        case .version:
+            return "Version"
+        case .warning:
+            return "Warning"
+        }
+    }
+}
+
+// MARK: - Codable
+
+extension Callout.Delimiter: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let delimiter = Self(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "invalid callout delimiter: \(rawValue)")
+        }
+
+        self = delimiter
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
     }
 }

--- a/Sources/SwiftMarkup/Callout.swift
+++ b/Sources/SwiftMarkup/Callout.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// A documentation callout, such as a note, remark, or warning.
 public struct Callout: Hashable, Codable {
+    /// A label that marks the beginning of a callout.
     public enum Delimiter: Hashable {
         /**
          Highlighted information for the user of the symbol.

--- a/Sources/SwiftMarkup/Documentation.swift
+++ b/Sources/SwiftMarkup/Documentation.swift
@@ -118,7 +118,7 @@ extension Documentation {
             }
 
             let string = node.description
-            let pattern = #"\s*[\-\+\*]\s*(?<parameter>(?:Parameter\s+)?)(?<name>[\w\h]+):(\s*(?<description>.+))?"#
+            let pattern = #"\s*[\-\+\*]\s*(?<parameter>(?:Parameter\s+)?)(?<name>[\w\h]+|Custom\(.+\)):(\s*(?<description>.+))?"#
             let regularExpression = try NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators, .caseInsensitive])
 
             guard let match = regularExpression.firstMatch(in: string, options: [], range: NSRange(string.startIndex ..< string.endIndex, in: string)),
@@ -156,7 +156,7 @@ extension Documentation {
                     documentation.returns = try Document(description)
                 } else if name.caseInsensitiveCompare("throws") == .orderedSame {
                     documentation.throws = try Document(description)
-                } else if let delimiter = Callout.Delimiter(name) {
+                } else if let delimiter = Callout.Delimiter(rawValue: name) {
                     let callout = Callout(delimiter: delimiter, content: description)
                     documentation.discussionParts += [.callout(callout)]
                 } else {

--- a/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
+++ b/Tests/SwiftMarkupTests/SwiftMarkupTests.swift
@@ -27,6 +27,7 @@ let bicycle = Bicycle(gearing: .fixed, handlebar: .drop, frameSize: 170)
 
 - Author: Mattt
 - Complexity: `O(1)`
+- Custom(🚲): 🔥
 - Parameter style: The style of the bicycle
 - Parameters:
    - gearing: The gearing of the bicycle
@@ -46,7 +47,7 @@ final class SwiftMarkupTests: XCTestCase {
         XCTAssertEqual(documentation.isEmpty, false)
 
         XCTAssertEqual(documentation.summary?.description, "Creates a new bicycle with the provided parts and specifications.\n")
-        XCTAssertEqual(documentation.discussionParts.count, 8)
+        XCTAssertEqual(documentation.discussionParts.count, 9)
 
         guard case .callout(let remark) = documentation.discussionParts[0] else { return XCTFail() }
         XCTAssertEqual(remark.delimiter, .remark)
@@ -72,6 +73,13 @@ final class SwiftMarkupTests: XCTestCase {
         guard case .callout(let complexity) = documentation.discussionParts[7] else { return XCTFail() }
         XCTAssertEqual(complexity.delimiter, .complexity)
         XCTAssertEqual(complexity.content, "`O(1)`")
+
+        guard case .callout(let custom) = documentation.discussionParts[8],
+              case .custom(let delimiter) = custom.delimiter
+        else { return XCTFail() }
+
+        XCTAssertEqual(delimiter, "🚲")
+        XCTAssertEqual(custom.content, "🔥")
 
         XCTAssertEqual(documentation.parameters.count, 4)
         XCTAssertEqual(documentation.parameters[0].name, "style")


### PR DESCRIPTION
Xcode supports [custom callouts](https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/CustomCallouts.html#//apple_ref/doc/uid/TP40016497-CH59-SW1) only in Playgrounds, but these would be generally useful (unlike the other Playground-specific features like "Next / Previous Page").  